### PR TITLE
Improve local fix prompting and instruction file permissions

### DIFF
--- a/go/internal/config/instructions.go
+++ b/go/internal/config/instructions.go
@@ -17,8 +17,17 @@ func FormatInstructions(text string) string {
 // The function checks for the file existence and reads it, wrapping the content in a clear format
 func LoadInstructions(path string) (string, error) {
 	// Check if file exists
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
 		return "", nil // File doesn't exist, return empty string (not an error)
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to stat instructions file: %w", err)
+	}
+
+	// Ensure the file is readable
+	if info.Mode().Perm()&0444 == 0 {
+		return "", fmt.Errorf("instructions file is not readable: permission denied")
 	}
 
 	// Read the file

--- a/go/internal/interactive/prompt_test.go
+++ b/go/internal/interactive/prompt_test.go
@@ -274,3 +274,38 @@ func TestActionableItem(t *testing.T) {
 		t.Errorf("ActionableItem.IssueNum = %d, want 123", *item2.IssueNum)
 	}
 }
+
+func TestBuildLocalFixPrompt(t *testing.T) {
+	finding := findings.Finding{
+		ID:             "SEC-002",
+		Title:          "Example finding",
+		Description:    "A description of the issue",
+		Recommendation: "Follow best practices",
+		Files:          []string{"file1.txt", "dir/file2.go"},
+	}
+
+	prompt := buildLocalFixPrompt(ActionableItem{Finding: &finding})
+
+	if !strings.Contains(prompt, finding.ID) {
+		t.Errorf("prompt should include finding ID %q", finding.ID)
+	}
+	if !strings.Contains(prompt, finding.Title) {
+		t.Errorf("prompt should include finding title %q", finding.Title)
+	}
+	if !strings.Contains(prompt, finding.Description) {
+		t.Errorf("prompt should include finding description")
+	}
+	if !strings.Contains(prompt, finding.Recommendation) {
+		t.Errorf("prompt should include finding recommendation")
+	}
+	if !strings.Contains(prompt, "file1.txt") || !strings.Contains(prompt, "dir/file2.go") {
+		t.Errorf("prompt should include related files")
+	}
+
+	issueNum := 42
+	issuePrompt := buildLocalFixPrompt(ActionableItem{IsExisting: true, IssueNum: &issueNum, IssueTitle: "Existing bug"})
+
+	if !strings.Contains(issuePrompt, "#42") || !strings.Contains(issuePrompt, "Existing bug") {
+		t.Errorf("prompt should include existing issue details")
+	}
+}


### PR DESCRIPTION
## Summary
- Pass contextual prompts to Copilot local fix sessions and add prompt builder coverage
- Ensure instruction files without read permissions return a clear error

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937211e3f108333942e3d202cfe6d31)